### PR TITLE
#64 チーム情報の操作に関しての機能を整えること/Implement team information management function 

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -49,10 +49,7 @@ class AssignsController < ApplicationController
 
   def ensure_correct_user
     assign = Assign.find(params[:id])
-    # binding.pry
-    if current_user == assign.team.owner
-    elsif current_user == assign.user
-    else
+    unless current_user == assign.team.owner || current_user == assign.user
       flash[:notice] = "権限がありません"
       redirect_to team_url(params[:team_id])
     end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -1,5 +1,6 @@
 class AssignsController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_correct_user, only:[:destroy]
 
   def create
     team = Team.friendly.find(params[:team_id])
@@ -15,7 +16,6 @@ class AssignsController < ApplicationController
   def destroy
     assign = Assign.find(params[:id])
     destroy_message = assign_destroy(assign, assign.user)
-
     redirect_to team_url(params[:team_id]), notice: destroy_message
   end
 
@@ -45,5 +45,16 @@ class AssignsController < ApplicationController
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
+  end
+
+  def ensure_correct_user
+    assign = Assign.find(params[:id])
+    # binding.pry
+    if current_user == assign.team.owner
+    elsif current_user == assign.user
+    else
+      flash[:notice] = "権限がありません"
+      redirect_to team_url(params[:team_id])
+    end
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,13 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    if current_user == @team.owner
+    else
+      flash[:notice] = "権限がありません"
+      redirect_to team_url#(params[:team_id])
+    end
+  end
 
   def create
     @team = Team.new(team_params)
@@ -57,11 +63,11 @@ class TeamsController < ApplicationController
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
   end
 
-  def ensure_correct_user
-    @task = Task.find(params[:id])
-    if current_user.id != @task.user.id
-      flash[:notice] = "権限がありません"
-      redirect_to root_path
-    end
-  end
+  # def ensure_correct_user
+  #   @task = Task.find(params[:id])
+  #   if current_user.id != @task.user.id
+  #     flash[:notice] = "権限がありません"
+  #     redirect_to root_path
+  #   end
+  # end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -56,4 +56,12 @@ class TeamsController < ApplicationController
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
   end
+
+  def ensure_correct_user
+    @task = Task.find(params[:id])
+    if current_user.id != @task.user.id
+      flash[:notice] = "権限がありません"
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -16,8 +16,7 @@ class TeamsController < ApplicationController
   end
 
   def edit
-    if current_user == @team.owner
-    else
+    unless current_user == @team.owner
       flash[:notice] = "権限がありません"
       redirect_to team_url#(params[:team_id])
     end
@@ -63,11 +62,4 @@ class TeamsController < ApplicationController
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
   end
 
-  # def ensure_correct_user
-  #   @task = Task.find(params[:id])
-  #   if current_user.id != @task.user.id
-  #     flash[:notice] = "権限がありません"
-  #     redirect_to root_path
-  #   end
-  # end
 end


### PR DESCRIPTION
issue1 「#64 チーム情報の操作に関しての機能を整えること」
コミットID 2000d57

● Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにする
● TeamのeditはTeamのリーダー（オーナー）のみができるようにする
